### PR TITLE
Pin the collection version

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,2 +1,3 @@
 collections:
   - name: community.general
+    version: ">=7.5.1"

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,3 +1,5 @@
 collections:
   - name: community.general
     version: ">=7.5.1"
+  - name: awx.awx
+    version: ">=22.7.0"


### PR DESCRIPTION
This speeds up the install greatly, as Galaxy otherwise has to pull every version and test for dependencies