### PR TITLE
Specify a repo_dir or destination dir for exports

### DIFF
--- a/export.yml
+++ b/export.yml
@@ -5,7 +5,7 @@
   vars:
     # Var for setting repo destination for importing
     # Can be passed as extra_vars in job template
-    repo_dir: /path/to/repo/config # Change to path to your repo / fork 
+    # repo_dir: /path/to/repo/config # Change to path to your repo / fork 
     # These are the objects you wish to export.  Be sure to comment out any you don't want.
     export_objects: 
       - applications

--- a/export.yml
+++ b/export.yml
@@ -44,6 +44,7 @@
       path: /tmp/export_files
       state: directory
       mode: '0755'
+    when: repo_dir is undefined
 
   - name: create all of the export files from template file
     ansible.builtin.template:

--- a/export.yml
+++ b/export.yml
@@ -3,6 +3,9 @@
   hosts: save-files
   gather_facts: false
   vars:
+    # Var for setting repo destination for importing
+    # Can be passed as extra_vars in job template
+    repo_dir: /path/to/repo/config # Change to path to your repo / fork 
     # These are the objects you wish to export.  Be sure to comment out any you don't want.
     export_objects: 
       - applications

--- a/export_template.yml.j2
+++ b/export_template.yml.j2
@@ -9,5 +9,5 @@
   ansible.builtin.copy:
     # Fixes for inventory removing --- and some other introduced noise
     content: "{% raw %}{{ exported_info | to_nice_yaml( width=50, explicit_start=True, explicit_end=True) |  regex_replace('assets:', '') | regex_replace('changed: false', '') | regex_replace('failed: false', '') | regex_replace('---', '') }}{% endraw %}"
-    dest: "{{ repo_dir | default('/tmp/export_files',ture) }}/{{ item }}.yml"
+    dest: "{{ repo_dir | default('/tmp/export_files') }}/{{ item }}.yml"
 

--- a/export_template.yml.j2
+++ b/export_template.yml.j2
@@ -9,4 +9,5 @@
   ansible.builtin.copy:
     # Fixes for inventory removing --- and some other introduced noise
     content: "{% raw %}{{ exported_info | to_nice_yaml( width=50, explicit_start=True, explicit_end=True) |  regex_replace('assets:', '') | regex_replace('changed: false', '') | regex_replace('failed: false', '') | regex_replace('---', '') }}{% endraw %}"
-    dest: "/tmp/export_files/{{ item }}.yml"
+    dest: "{{ repo_dir }}/{{ item }}.yml"
+

--- a/export_template.yml.j2
+++ b/export_template.yml.j2
@@ -9,5 +9,5 @@
   ansible.builtin.copy:
     # Fixes for inventory removing --- and some other introduced noise
     content: "{% raw %}{{ exported_info | to_nice_yaml( width=50, explicit_start=True, explicit_end=True) |  regex_replace('assets:', '') | regex_replace('changed: false', '') | regex_replace('failed: false', '') | regex_replace('---', '') }}{% endraw %}"
-    dest: "{{ repo_dir }}/{{ item }}.yml"
+    dest: "{{ repo_dir | default('/tmp/export_files',ture) }}/{{ item }}.yml"
 


### PR DESCRIPTION
Added a variable that can be added in `exports.yml` or as an `extra_vars` for the user to specify the path where the exported files go, but set a default path to be the same as original play.